### PR TITLE
Add rewrite rules for policy slugs and update sitemap

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,6 +5,10 @@ RewriteCond %{HTTPS} off [OR]
 RewriteCond %{HTTP_HOST} ^www\.e-notifyer\.nl$ [NC]
 RewriteRule ^(.*)$ https://e-notifyer.nl/$1 [L,R=301]
 
+# Pretty URL rewrites for policy pages
+RewriteRule ^privacy-policy/?$ privacy.php [L]
+RewriteRule ^cookie-policy/?$ cookie.php [L]
+
 # Optional: rewrite extensionless URLs
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME}.php -f

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,22 +12,17 @@
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://e-notifyer.nl/index.php</loc>
+  <loc>https://e-notifyer.nl/contact</loc>
   <lastmod>2024-12-26T09:04:11+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://e-notifyer.nl/contact.php</loc>
+  <loc>https://e-notifyer.nl/privacy-policy</loc>
   <lastmod>2024-12-26T09:04:11+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://e-notifyer.nl/privacy.php</loc>
-  <lastmod>2024-12-26T09:04:11+00:00</lastmod>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://e-notifyer.nl/cookie.php</loc>
+  <loc>https://e-notifyer.nl/cookie-policy</loc>
   <lastmod>2024-12-26T09:04:11+00:00</lastmod>
   <priority>0.80</priority>
 </url>


### PR DESCRIPTION
## Summary
- add explicit rewrite rules so `/privacy-policy` and `/cookie-policy` load the existing PHP files
- update sitemap URLs to match extensionless slugs

## Testing
- `php -l index.php contact.php privacy.php cookie.php send_email.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dfd4cffc83248485938d09a631af