### PR TITLE
Fix www redirect

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,8 +1,11 @@
 RewriteEngine On
 
-# Redirect www and force HTTPS
-RewriteCond %{HTTPS} off [OR]
+# Redirect www.e-notifyer.nl to the canonical HTTPS domain
 RewriteCond %{HTTP_HOST} ^www\.e-notifyer\.nl$ [NC]
+RewriteRule ^(.*)$ https://e-notifyer.nl/$1 [L,R=301]
+
+# Force HTTPS on the canonical domain
+RewriteCond %{HTTPS} off
 RewriteRule ^(.*)$ https://e-notifyer.nl/$1 [L,R=301]
 
 # Pretty URL rewrites for policy pages


### PR DESCRIPTION
## Summary
- force canonical HTTPS domain in `.htaccess`
- ensure internal links already use the canonical domain

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e303b860832481dbe3f0c3b14998