### PR TITLE
Improve email handling security

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,0 +1,4 @@
+<?php
+// Configuration settings
+$recipient = getenv('CONTACT_RECIPIENT') ?: 'info@example.com';
+?>

--- a/contact.php
+++ b/contact.php
@@ -62,6 +62,7 @@
                                 <div class="form-group">
                                     <label class="my-2" for="message">Bericht</label>
                                     <textarea class="form-control" id="message" name="message" rows="5" placeholder="Schrijf je bericht" required></textarea>
+                                    <input type="text" name="website" id="website" style="display:none">
                                 </div>
                                 <button type="submit" class="btn btn-primary btn-xl rounded-pill mt-5">Verzenden</button>
                                 <div id="responseMessage" class="mt-3"></div> <!-- Dit is de plek voor het antwoord -->

--- a/send_email.php
+++ b/send_email.php
@@ -3,17 +3,20 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     // Haal de ingevulde gegevens uit het formulier
     $name = strip_tags(trim($_POST["name"]));
     $email = filter_var(trim($_POST["email"]), FILTER_SANITIZE_EMAIL);
+    $email = str_replace(["\r", "\n"], '', $email); // verwijder nieuwe regels voor veiligheid
     $message = trim($_POST["message"]);
+    $honeypot = isset($_POST["website"]) ? trim($_POST["website"]) : '';
 
     // Controleer of alle velden ingevuld zijn
-    if (empty($name) || empty($email) || empty($message) || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    if (empty($name) || empty($email) || empty($message) || !filter_var($email, FILTER_VALIDATE_EMAIL) || !empty($honeypot)) {
         http_response_code(400);
         echo "Er was een probleem met je inzending. Zorg ervoor dat alle velden correct zijn ingevuld.";
         exit;
     }
 
-    // Ontvanger e-mailadres (vervang dit met jouw e-mailadres)
-    $recipient = "jouw-email@voorbeeld.nl"; // Vervang dit met je echte e-mailadres
+    // Laad configuratie
+    require_once __DIR__ . '/config.php';
+    // $recipient wordt ingeladen uit config.php
 
     // Onderwerp van de e-mail
     $subject = "Nieuw contactbericht van $name";


### PR DESCRIPTION
## Summary
- add `config.php` for configuration and environment variable `$recipient`
- sanitize email input against header injection in `send_email.php`
- add honeypot field to contact form as basic spam protection

## Testing
- `php -l send_email.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852e58156248324bb1ffcf178644b27