### PR TITLE
Update HTTPS redirect rule

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,7 +4,8 @@ RewriteEngine On
 RewriteCond %{HTTP_HOST} ^www\.e-notifyer\.nl$ [NC]
 RewriteRule ^(.*)$ https://e-notifyer.nl/$1 [L,R=301]
 
-# Force HTTPS on the canonical domain
+# Force HTTPS only for the public domains
+RewriteCond %{HTTP_HOST} ^(www\.)?e-notifyer\.nl$ [NC]
 RewriteCond %{HTTPS} off
 RewriteRule ^(.*)$ https://e-notifyer.nl/$1 [L,R=301]
 


### PR DESCRIPTION
## Summary
- restrict HTTPS redirect to production hosts only

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e96f624c8324a752723690ca6fec