### PR TITLE
Move contact form JS to external file

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -67,24 +67,4 @@
         <!-- Footer-->
         <!-- jQuery toevoegen -->
         <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-        <script>
-            $(document).ready(function() {
-                $('#contactForm').on('submit', function(event) {
-                    event.preventDefault(); // Voorkom dat het formulier normaal wordt verzonden
-                    
-                    $.ajax({
-                        type: 'POST',
-                        url: 'send_email.php',
-                        data: $(this).serialize(), // Verzend de gegevens van het formulier
-                        success: function(response) {
-                            $('#responseMessage').html('<div class="alert alert-success">' + response + '</div>');
-                            $('#contactForm')[0].reset(); // Reset het formulier na een succesvolle verzending
-                        },
-                        error: function() {
-                            $('#responseMessage').html('<div class="alert alert-danger">Er is iets misgegaan. Probeer het later opnieuw.</div>');
-                        }
-                    });
-                });
-            });
-        </script>
         <?php include 'footer.php'; ?>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -5,3 +5,23 @@
 */
 // This file is intentionally blank
 // Use this file to add JavaScript to your project
+
+// Contact form handling
+$(document).ready(function () {
+    $('#contactForm').on('submit', function (event) {
+        event.preventDefault();
+
+        $.ajax({
+            type: 'POST',
+            url: 'send_email.php',
+            data: $(this).serialize(),
+            success: function (response) {
+                $('#responseMessage').html('<div class="alert alert-success">' + response + '</div>');
+                $('#contactForm')[0].reset();
+            },
+            error: function () {
+                $('#responseMessage').html('<div class="alert alert-danger">Er is iets misgegaan. Probeer het later opnieuw.</div>');
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- move jQuery contact form handler into `js/scripts.js`
- load the external script in `contact.php` rather than inline code

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852e976eee083248831ffe37e43c476